### PR TITLE
[bugfix] Don't attempt to download undownloadable files

### DIFF
--- a/SlackExtract.ps1
+++ b/SlackExtract.ps1
@@ -394,6 +394,14 @@ function getFilesforChannelOrGroup($channelOrGroupDir){
 
 
 			$fileUrl = $file.url_private_download
+
+			# adding a fix here for "special" files like linked google docs
+			# which Slack treats as a file but cannot be downloaded
+			if (! $fileUrl ) {
+				Write-Host "Skipping file $($file.id), as it has no downloadable URL"
+				continue
+			}
+
 			$fileName = Join-Path -Path $dirMinusMeta -ChildPath $($file.id + "_" + $fileUrl.Substring($fileUrl.LastIndexOf("/") + 1))
 			if(test-path $fileName){ Write-Host "Skipping already existing file $fileName"}
 			else


### PR DESCRIPTION
Slack treats some links as files, such as when a Google Doc is linked in a conversation. The downloader will try to download such files, but will fail because these files are really just fancy links and therefore have no `url_private_download` property.

For example, the the Slack API considers the following message to contain a file, even though it is really just a link to a Google Doc:
![special_file_issue](https://user-images.githubusercontent.com/13520045/95132797-402adf00-0758-11eb-89ee-49a5ecd03f23.png)

(sorry for the heavily-redacted image - this was on a channel where I haven't got permission to post content externally)

This change fixes this bug by skipping all "files" that do not have a `url_private_download` attribute. For each skipped "file", a warning message is printed.

---
@clr2of8 If this PR is a useful contribution, I'd really appreciate you labelling it with the `hacktoberfest-accepted` label so that it counts towards [Hacktoberfest](https://hacktoberfest.digitalocean.com/details#rules). Thanks! (Oh, and I've got some more changes I'll try to upstream from my modified version in the next few weeks, including fixes for #2 and #3).