### PR TITLE
Download user profile images

### DIFF
--- a/SlackExtract.ps1
+++ b/SlackExtract.ps1
@@ -238,6 +238,18 @@ function Shazam($apiEndpoint, $requestBody, $type, $limit, $folder){
 			$fn = Join-Path -Path $folder -ChildPath "$name.json"
 			if(!(test-path $fn)){
 				$message | ConvertTo-Json | Out-File $fn
+				if ($type -eq "user") {
+					# download user profile pictures
+					$session = getSession
+					$profileImageTypes = "original", "1024", "512", "192", "72", "48", "32", "24"
+					foreach ($imageType in $profileImageTypes) {
+						if ($message.profile."image_$imageType") {
+							$imagePath = Join-Path -Path $folder -ChildPath "$($name)_image_$($imageType).png"
+							Invoke-WebRequest -Uri $message.profile."image_$imageType" -WebSession $session -UserAgent $ua -OutFile $imagePath
+							break
+						}
+					}
+				}
 			}
 			else {
 				if($type -ne "message"){Write-Host -ForegroundColor Yellow "Skipping already existing file: $fn"}


### PR DESCRIPTION
When running the script with the `-ExtractUsers` flag, it will now attempt to download the highest-quality version of the profile image for each user that is available. It does this by reading the user metadata, and looping through the following JSON attributes:
`image_original`, `image_1024`, `image_512`, `image_192`, `image_72`, `image_48`, `image_32`, `image_24`

Once a profile image has successfully been downloaded, the loop exits, so only the single highest-quality image is downloaded. This saves on disk space and bandwidth, and significantly reduces the running time of what would otherwise be a large number of downloads.

When ordered as above, these attributes represent the possible profile image URLs available in the user metadata, from highest-quality to lowest-quality (it may be the case that `image_original` is of a lower resolution than one of the other available images, but those other versions are all derived by Slack from the original and so will just be upscaled / pixelated versions). 

For some reason not all users have all of the above attributes, hence why they must be looped through in the above order in order to attempt to get the highest-quality version. Slack's [API documentation](https://api.slack.com/types/user#fields) isn't helpful here, it just lists the possible fields as `profile.image_*`. I've tested this on two different Slack groups, one with 11 users and the other with over 150 users, and both of them contained, in aggregate, all the JSON attributed listed above. Therefore I think the above list is exhaustive, although it would be trivial to add more in if they were discovered later.

As with #5, I've made this the default behaviour when fetching user profiles with the `-ExtractUsers` flag. I think this is a sensible default, but would be happy to change this to a separate flag if you didn't want to change how the script currently operates.

---
Oh, if you're happy with this PR I'd appreciate it if you labelled it with the `hacktoberfest-accepted` label, like before.